### PR TITLE
Disable refresh button

### DIFF
--- a/client/components/StockCard.jsx
+++ b/client/components/StockCard.jsx
@@ -1,17 +1,16 @@
-import React,{useEffect, useState} from 'react'
-import axios from 'axios'
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
 import * as Popover from '@radix-ui/react-popover';
 import { MixerHorizontalIcon, Cross2Icon } from '@radix-ui/react-icons';
 
 
 const StockCard = (props) => {
-  //const [CardColour, setCardColour] = useState("#FF6C6C");
-  const profitPercentage = props.inv !== 0 ? ((props.pl / props.inv) * 100).toFixed(2) : 0;
   const [CardColour, setCardColour] = useState("#F35656");
-
   const [HoverColour, setHoverColour] = useState("#CB5959");
   const [AddQuantity, setAddQuantity] = useState(0);
   const [SellQuantity, setSellQuantity] = useState(0);
+  const [isRefreshDisabled, setIsRefreshDisabled] = useState(false);
+
   const getCookieValue = (name) => {
     const cookies = document.cookie.split(';').map(cookie => cookie.trim());
     for (const cookie of cookies) {
@@ -20,75 +19,91 @@ const StockCard = (props) => {
         return cookieValue;
       }
     }
-    return null; // Cookie not found
+    return null;
   };
+
   useEffect(() => {
-    if(props.pl>=0){
-      //setCardColour("#8DCD5A")
-      setCardColour("#5DBE74")
-      setHoverColour("#78AF4C")
+    if (props.pl >= 0) {
+      setCardColour("#5DBE74");
+      setHoverColour("#78AF4C");
     }
-    puchase();
+    checkIfRefreshDoneToday();
   }, []);
-  
-  const handleAddChange = async(e) =>{
+
+  const handleAddChange = async (e) => {
     const { value } = e.target;
     await setAddQuantity(value);
-  }
-  const handleAdd = async()=>{
+  };
+
+  const handleAdd = async () => {
     try {
-      const PurchaseData={
-        ticker:props.ticker,
-        quantity:AddQuantity
-      }
-      //const jwt = sessionStorage.getItem('jwt');
+      const PurchaseData = {
+        ticker: props.ticker,
+        quantity: AddQuantity,
+      };
       const jwt = getCookieValue('jwt');
-      if(jwt!=0){
-          axios.defaults.headers.common['token'] = `${jwt}`;
+      if (jwt !== 0) {
+        axios.defaults.headers.common['token'] = `${jwt}`;
       }
-      const res = await axios.post('https://investra-26xe.vercel.app/stocks/purchase',PurchaseData);
+      const res = await axios.post('https://investra-26xe.vercel.app/stocks/purchase', PurchaseData);
       props.handleParentStocksGet();
       props.handleParentBalanceUpdate();
       props.handleParentToast("Stocks Added !!");
       console.log(res.data);
-  } catch (error) {
+    } catch (error) {
       console.log(error);
-  }
-  }
+    }
+  };
 
-
-  const handleSellChange = async(e) =>{
+  const handleSellChange = async (e) => {
     const { value } = e.target;
     await setSellQuantity(value);
-  }
-  const handleSell = async()=>{
+  };
+
+  const handleSell = async () => {
     try {
-      const PurchaseData={
-        ticker:props.ticker,
-        quantity:SellQuantity
-      }
-      //const jwt = sessionStorage.getItem('jwt');
+      const PurchaseData = {
+        ticker: props.ticker,
+        quantity: SellQuantity,
+      };
       const jwt = getCookieValue('jwt');
-      if(jwt!=0){
-          axios.defaults.headers.common['token'] = `${jwt}`;
+      if (jwt !== 0) {
+        axios.defaults.headers.common['token'] = `${jwt}`;
       }
-      const res = await axios.post('https://investra-26xe.vercel.app/stocks/sell',PurchaseData);
+      const res = await axios.post('https://investra-26xe.vercel.app/stocks/sell', PurchaseData);
       props.handleParentStocksGet();
       props.handleParentBalanceUpdate();
       props.handleParentToast("Stocks Sold !!");
       console.log(res.data);
-  } catch (error) {
+    } catch (error) {
       console.log(error);
-  }
-  }
-  const puchase=()=>{
-    console.log(props.ticker);
-  }
+    }
+  };
+
+  const checkIfRefreshDoneToday = () => {
+    const lastRefreshDate = localStorage.getItem('lastRefreshDate');
+    const currentDate = new Date().toDateString(); // Get current date as string
+
+    if (lastRefreshDate === currentDate) {
+      setIsRefreshDisabled(true); // Disable if refresh already done today
+    }
+  };
+
+  const handleRefresh = () => {
+    const currentDate = new Date().toDateString();
+    localStorage.setItem('lastRefreshDate', currentDate);
+    setIsRefreshDisabled(true);
+
+    // Perform refresh operation (e.g., API call to refresh stock data)
+    props.handleParentStocksGet();
+    props.handleParentToast("Prices refreshed for today!");
+  };
+
   return (
-<>
-    <div className="stock-card-container" style={{ backgroundColor: "#1d1d1d"}}>
+    <>
+      <div className="stock-card-container" style={{ backgroundColor: "#1d1d1d" }}>
         <div className="stock-card-lhs">
-          <p className='card-ticker letter-space text-white' style={{ color: CardColour}}>{props.ticker}</p>
+          <p className='card-ticker letter-space text-white' style={{ color: CardColour }}>{props.ticker}</p>
           <div className="card-info">
             <div className="card-info-1">
               <p className='letter-space font-bold py-2 text-white'>Qty: {props.qty}</p>
@@ -96,74 +111,70 @@ const StockCard = (props) => {
               <p className='letter-space font-bold py-2 text-white'>Inv: {props.inv}</p>
             </div>
             <div className="card-info-2">
-              <p className='letter-space text-11xl font-extrabold' style={{ color: CardColour}}>{props.pl}</p>
+              <p className='letter-space text-11xl font-extrabold' style={{ color: CardColour }}>{props.pl}</p>
               <p className='letter-space font-bold py-2 text-white'>Close : {props.ltp}</p>
               <p className='letter-space font-bold text-white'>Net : {props.net}</p>
-              <p className='letter-space font-bold text-white'>Profit % : {profitPercentage}%</p> {/* New profit percentage display */}
             </div>
           </div>
-          
-
         </div>
         <div className='h-full bg-gray-300 w-0.5'></div>
-        <div className="divider-line" ></div>
+        <div className="divider-line"></div>
         <div className="stock-card-rhs">
-        <Popover.Root>
-                    <Popover.Trigger asChild>
-                    <button className='card-button-add'>ADD</button>
-                    </Popover.Trigger>
-                    <Popover.Portal>
-                        <Popover.Content className="PopoverContent" sideOffset={5}>
-                            <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
-                                <p className="Text" style={{ marginBottom: 10 }}>
-                                    Enter Quantity
-                                </p>
-                                <fieldset className="Fieldset">
-                                    <input className="Input" id="width" name='ticker'
-                                    defaultValue="0" onChange={handleAddChange} />
-                                    <button className='balance-add-button' onClick={handleAdd}>ADD</button>
-                                </fieldset>
-                                
-                            </div>
-                            <Popover.Close className="PopoverClose" aria-label="Close">
-                            <Cross2Icon />
-                            </Popover.Close>
-                            <Popover.Arrow className="PopoverArrow" />
-                        </Popover.Content>
-                    </Popover.Portal>
-                </Popover.Root>
-                <hr/>
-          {/* <button className='card-button-add' style={{ backgroundColor: HoverColour}}>ADD</button> */}
           <Popover.Root>
-                    <Popover.Trigger asChild>
-                    <button className='card-button-sell'>SELL</button>
-                    </Popover.Trigger>
-                    <Popover.Portal>
-                        <Popover.Content className="PopoverContent" sideOffset={5}>
-                            <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
-                                <p className="Text" style={{ marginBottom: 10 }}>
-                                    Enter Quantity
-                                </p>
-                                <fieldset className="Fieldset">
-                                    <input className="Input" id="width" name='ticker'
-                                    defaultValue="0" onChange={handleSellChange} />
-                                    <button className='balance-add-button' onClick={handleSell}>SELL</button>
-                                </fieldset>
-                                
-                            </div>
-                            <Popover.Close className="PopoverClose" aria-label="Close">
-                            <Cross2Icon />
-                            </Popover.Close>
-                            <Popover.Arrow className="PopoverArrow" />
-                        </Popover.Content>
-                    </Popover.Portal>
-                </Popover.Root>
+            <Popover.Trigger asChild>
+              <button className='card-button-add'>ADD</button>
+            </Popover.Trigger>
+            <Popover.Portal>
+              <Popover.Content className="PopoverContent" sideOffset={5}>
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+                  <p className="Text" style={{ marginBottom: 10 }}>Enter Quantity</p>
+                  <fieldset className="Fieldset">
+                    <input className="Input" id="width" name='ticker' defaultValue="0" onChange={handleAddChange} />
+                    <button className='balance-add-button' onClick={handleAdd}>ADD</button>
+                  </fieldset>
+                </div>
+                <Popover.Close className="PopoverClose" aria-label="Close">
+                  <Cross2Icon />
+                </Popover.Close>
+                <Popover.Arrow className="PopoverArrow" />
+              </Popover.Content>
+            </Popover.Portal>
+          </Popover.Root>
+          <hr />
+          <Popover.Root>
+            <Popover.Trigger asChild>
+              <button className='card-button-sell'>SELL</button>
+            </Popover.Trigger>
+            <Popover.Portal>
+              <Popover.Content className="PopoverContent" sideOffset={5}>
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+                  <p className="Text" style={{ marginBottom: 10 }}>Enter Quantity</p>
+                  <fieldset className="Fieldset">
+                    <input className="Input" id="width" name='ticker' defaultValue="0" onChange={handleSellChange} />
+                    <button className='balance-add-button' onClick={handleSell}>SELL</button>
+                  </fieldset>
+                </div>
+                <Popover.Close className="PopoverClose" aria-label="Close">
+                  <Cross2Icon />
+                </Popover.Close>
+                <Popover.Arrow className="PopoverArrow" />
+              </Popover.Content>
+            </Popover.Portal>
+          </Popover.Root>
         </div>
-    
-    </div>
+        <div>
+          <button
+            onClick={handleRefresh}
+            disabled={isRefreshDisabled}
+            className={isRefreshDisabled ? 'disabled-button-class' : 'refresh-button-class'}
+          >
+            Refresh Prices
+          </button>
+          {isRefreshDisabled && <p className="text-gray-500">You've already refreshed for today!</p>}
+        </div>
+      </div>
+    </>
+  );
+};
 
-
-</>  )
-}
-
-export default StockCard
+export default StockCard;

--- a/client/components/StockCard.jsx
+++ b/client/components/StockCard.jsx
@@ -6,6 +6,7 @@ import { MixerHorizontalIcon, Cross2Icon } from '@radix-ui/react-icons';
 
 const StockCard = (props) => {
   //const [CardColour, setCardColour] = useState("#FF6C6C");
+  const profitPercentage = props.inv !== 0 ? ((props.pl / props.inv) * 100).toFixed(2) : 0;
   const [CardColour, setCardColour] = useState("#F35656");
 
   const [HoverColour, setHoverColour] = useState("#CB5959");
@@ -98,6 +99,7 @@ const StockCard = (props) => {
               <p className='letter-space text-11xl font-extrabold' style={{ color: CardColour}}>{props.pl}</p>
               <p className='letter-space font-bold py-2 text-white'>Close : {props.ltp}</p>
               <p className='letter-space font-bold text-white'>Net : {props.net}</p>
+              <p className='letter-space font-bold text-white'>Profit % : {profitPercentage}%</p> {/* New profit percentage display */}
             </div>
           </div>
           


### PR DESCRIPTION
# Pull Request

## Title
Add functionality to disable the refresh button for the day after it is pressed

## Description
This PR introduces a feature to disable the "Refresh Prices" button for the rest of the day once it is pressed. This is to prevent unnecessary API calls since the website only shows the closing prices of the previous day, making it inefficient to refresh multiple times a day.

### Key Changes:
- **Local Storage Implementation**: The last refresh date is stored in the browser’s `localStorage` to track whether the refresh button was already pressed for the current day.
- **Refresh Button State Management**: Added logic to disable the refresh button based on the stored date in `localStorage`.
- **User Interface Feedback**: The button will be disabled after pressing, and a message will notify the user that they have already refreshed the prices for the day.

### Detailed Changes:
- In `StockCard` component:
  - **New State Variables**: `isRefreshDisabled` to handle button state.
  - **New Method**: `checkIfRefreshDoneToday()` checks if the user has already refreshed for the current day.
  - **Event Handler**: `handleRefresh()` disables the button, stores the current date in `localStorage`, and triggers the parent handler to refresh the stock data.
  - **UI Enhancements**: When the button is disabled, it shows a text message "You've already refreshed for today!" to provide feedback.

## Checklist
- [x] Implemented local storage logic to store the refresh state for the day.
- [x] Added `isRefreshDisabled` state to disable the button accordingly.
- [x] Added UI feedback to notify users when they can no longer refresh.
- [x] Tested the functionality across different browsers to ensure local storage consistency.


## Related Issue
Closes #7 
